### PR TITLE
Add Counter Attack talent support

### DIFF
--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -203,6 +203,18 @@
     "medium": "M (24m)",
     "long": "L (36m)",
     "extreme": "Ex (72m)"
-  }
+  },
+
+  "IMPMAL_COMMUNITY.counterAttack.Name": "Counter Attack Talent Support",
+  "IMPMAL_COMMUNITY.counterAttack.Hint": "When the defender wins an opposed melee test and has the Counter Attack talent, a button appears on the chat card to initiate a counterattack. Uses are tracked per combat round per purchased rank of the talent. Requires restart.",
+  "IMPMAL_COMMUNITY.counterAttack.Disabled": "Disabled",
+  "IMPMAL_COMMUNITY.counterAttack.Enabled": "Enabled",
+  "IMPMAL_COMMUNITY.counterAttack.EnabledEnforced": "Enabled with enforced use limit",
+
+  "IMPMAL_COMMUNITY.CounterAttack.Button": "Counter Attack",
+  "IMPMAL_COMMUNITY.CounterAttack.Flavor": "Counter Attack",
+  "IMPMAL_COMMUNITY.CounterAttack.AlreadyApplied": "Counter Attack has already been applied for this attack.",
+  "IMPMAL_COMMUNITY.CounterAttack.Exhausted": "No Counter Attack uses remaining this round.",
+  "IMPMAL_COMMUNITY.CounterAttack.NoAttacker": "Could not find the attacking actor to apply Counter Attack damage."
 
 }

--- a/src/scripts/counterAttack/counterAttack.js
+++ b/src/scripts/counterAttack/counterAttack.js
@@ -1,0 +1,130 @@
+const MODULE_ID = "impmal-community";
+const FLAG_APPLIED = "counterAttackApplied";
+const FLAG_USAGE = "counterAttackUsage";
+const TALENT_NAME = "Counter Attack";
+
+export function registerCounterAttack() {
+    Hooks.once("ready", () => {
+        const cls = CONFIG.ChatMessage.documentClass;
+        const original = cls.prototype.renderHTML;
+        cls.prototype.renderHTML = async function(options) {
+            const html = await original.call(this, options);
+            if (this.type === "opposed") {
+                _injectCounterAttackButton(this, html);
+            }
+            return html;
+        };
+    });
+}
+
+function _getDefenderActor(message) {
+    return fromUuidSync(message.system.targetTokenUuid)?.actor ?? null;
+}
+
+function _getMaxUses(actor) {
+    const talent = actor.items.find(i => i.type === "talent" && i.name === TALENT_NAME);
+    return talent?.system?.taken ?? 0;
+}
+
+function _getUsedThisRound(actor) {
+    const currentRound = game.combat?.round ?? -1;
+    const usage = actor.getFlag(MODULE_ID, FLAG_USAGE) ?? { round: -1, used: 0 };
+    return usage.round === currentRound ? (usage.used ?? 0) : 0;
+}
+
+function _resolveCounterWeapon(defenderActor, defenderTest) {
+    const testItem = defenderTest?.item;
+    if (testItem?.system?.isMelee) return testItem;
+    return defenderActor.itemTypes.weapon.find(w => w.system.isEquipped && w.system.isMelee) ?? null;
+}
+
+function _injectCounterAttackButton(message, html) {
+    const result = message.system?.result;
+    if (!result || result.winner !== "defender") return;
+
+    const attackerTest = message.system.attackerTest;
+    const defenderTest = message.system.defenderTest;
+    if (!attackerTest || !defenderTest) return;
+
+    if (!attackerTest.item?.system?.isMelee) return;
+
+    const defenderActor = _getDefenderActor(message);
+    if (!defenderActor) return;
+
+    if (!defenderActor.isOwner && !game.user.isGM) return;
+
+    const maxUses = _getMaxUses(defenderActor);
+    if (maxUses === 0) return;
+
+    if (message.getFlag(MODULE_ID, FLAG_APPLIED)) return;
+
+    const weapon = _resolveCounterWeapon(defenderActor, defenderTest);
+    if (!weapon) return;
+
+    const buttonsDiv = html.querySelector(".opposed-buttons");
+    if (!buttonsDiv) return;
+
+    const usedThisRound = _getUsedThisRound(defenderActor);
+    const exhausted = usedThisRound >= maxUses;
+    const setting = game.settings.get(MODULE_ID, "counterAttack");
+    const blocked = exhausted && setting === "enabledEnforced";
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.classList.add("counter-attack-btn");
+    btn.disabled = blocked;
+    if (exhausted) btn.style.opacity = "0.5";
+    btn.dataset.tooltip = exhausted
+        ? game.i18n.localize("IMPMAL_COMMUNITY.CounterAttack.Exhausted")
+        : game.i18n.localize("IMPMAL_COMMUNITY.CounterAttack.Button");
+    btn.innerHTML = `<i class="fa-solid fa-sword"></i> ${game.i18n.localize("IMPMAL_COMMUNITY.CounterAttack.Button")} (${usedThisRound}/${maxUses})`;
+    btn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        _applyCounterAttack(message, defenderActor);
+    });
+    buttonsDiv.appendChild(btn);
+}
+
+async function _applyCounterAttack(message, defenderActor) {
+    if (message.getFlag(MODULE_ID, FLAG_APPLIED)) {
+        ui.notifications.warn(game.i18n.localize("IMPMAL_COMMUNITY.CounterAttack.AlreadyApplied"));
+        return;
+    }
+
+    const attackerTest = message.system.attackerTest;
+    if (!attackerTest?.actor) {
+        ui.notifications.error(game.i18n.localize("IMPMAL_COMMUNITY.CounterAttack.NoAttacker"));
+        return;
+    }
+
+    await message.setFlag(MODULE_ID, FLAG_APPLIED, true);
+
+    const currentRound = game.combat?.round ?? -1;
+    const usedThisRound = _getUsedThisRound(defenderActor);
+    await defenderActor.setFlag(MODULE_ID, FLAG_USAGE, { round: currentRound, used: usedThisRound + 1 });
+
+    const attackerMessage = game.messages.get(message.system.attackerMessageId);
+    const attackerSpeaker = attackerMessage?.speaker;
+    const attackerTokenUuid = (attackerSpeaker?.scene && attackerSpeaker?.token)
+        ? `Scene.${attackerSpeaker.scene}.Token.${attackerSpeaker.token}`
+        : null;
+
+    if (!attackerTokenUuid) {
+        ui.notifications.error(game.i18n.localize("IMPMAL_COMMUNITY.CounterAttack.NoAttacker"));
+        await message.unsetFlag(MODULE_ID, FLAG_APPLIED);
+        return;
+    }
+
+    const newMessage = await ChatMessage.create({
+        type: "opposed",
+        flavor: game.i18n.localize("IMPMAL_COMMUNITY.CounterAttack.Flavor"),
+        speaker: ChatMessage.getSpeaker({ actor: defenderActor }),
+        system: {
+            attackerMessageId: message.system.defenderMessageId,
+            defenderMessageId: message.system.attackerMessageId,
+            targetTokenUuid: attackerTokenUuid
+        }
+    });
+
+    await newMessage.system.renderContent();
+}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -6,6 +6,7 @@ import { registerAlternativeMasterCrafted } from "./alternativeMasterCrafted/alt
 import { registerAlternativeRend } from "./alternativeRend/alternativeRend.js";
 import { registerAutoCritKillHandling } from "./autoCritHandling/autoCritHandling.js";
 import { registerChangeConditionImages } from "./changeConditionImages/changeConditionImages.js";
+import { registerCounterAttack } from "./counterAttack/counterAttack.js";
 import { registerDeleteIniMessage } from "./deleteIni/deleteIni.js";
 import { registerDoublesEveryTest } from "./doublesEveryTest/doublesEveryTest.js";
 import { registerNotedRange } from "./notedRange/notedRange.js";
@@ -60,6 +61,10 @@ Hooks.on('init', () => {
 
     if (game.settings.get("impmal-community", "notedRange") === true) {
         registerNotedRange();
+    }
+
+    if (game.settings.get("impmal-community", "counterAttack") !== "disabled") {
+        registerCounterAttack();
     }
 
     registerPartySheet();

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -2,6 +2,7 @@ Hooks.on('init', () => {
     registerSettings();
 });
 
+
 function registerSettings() {
     game.settings.register("impmal-community", "alternativeInitiative", {
         name: game.i18n.localize("IMPMAL_COMMUNITY.alternativeInitiative.Name"),
@@ -141,5 +142,20 @@ function registerSettings() {
         default: false,
         requiresReload: true,
         type: Boolean
+    });
+
+    game.settings.register("impmal-community", "counterAttack", {
+        name: game.i18n.localize("IMPMAL_COMMUNITY.counterAttack.Name"),
+        hint: game.i18n.localize("IMPMAL_COMMUNITY.counterAttack.Hint"),
+        scope: "world",
+        config: true,
+        default: "disabled",
+        requiresReload: true,
+        type: String,
+        choices: {
+            disabled: game.i18n.localize("IMPMAL_COMMUNITY.counterAttack.Disabled"),
+            enabled: game.i18n.localize("IMPMAL_COMMUNITY.counterAttack.Enabled"),
+            enabledEnforced: game.i18n.localize("IMPMAL_COMMUNITY.counterAttack.EnabledEnforced")
+        }
     });
 }


### PR DESCRIPTION
<img width="286" height="542" alt="image" src="https://github.com/user-attachments/assets/55110691-3fb9-4ea9-9cca-f347e68ffa95" />
<img width="291" height="696" alt="image" src="https://github.com/user-attachments/assets/66580ec9-f2ed-4c88-a864-35f70b22767f" />

- Injects a Counter Attack button onto opposed chat cards when the
defender wins a melee test and has the Counter Attack talent

- Clicking the button creates a new opposed chat card with roles
swapped, using the vanilla Apply Damage flow

- Tracks uses per combat round based on the number of talent ranks
(talent.system.taken), greying out the button when uses are exhausted

- Adds a three-option module setting: Disabled / Enabled / Enabled
with enforced use limit